### PR TITLE
Updated Typescript declarations

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,16 +1,19 @@
-interface ReactCodeInput {
-  type: string;
-  onChange: (val: string) => void;
-  onComplete: (val: string) => void;
-  fields: number;
-  loading: boolean;
-  title: string;
-  fieldWidth: number;
-  fieldHeight: number;
-  autoFocus: boolean;
-  className: string;
+interface ReactCodeInputProps {
+  type?: 'text' | 'number';
+  onChange?: (val: string) => void;
+  onComplete?: (val: string) => void;
+  fields?: number;
+  loading?: boolean;
+  title?: string;
+  fieldWidth?: number;
+  fieldHeight?: number;
+  autoFocus?: boolean;
+  className?: string;
+  values?: string[];
+  disabled?: boolean;
+  required?: boolean;
 }
 
-declare const ReactCodeInput: ReactCodeInput;
+declare const ReactCodeInput: React.ComponentClass<ReactCodeInputProps>
 
 export default ReactCodeInput;


### PR DESCRIPTION
This PR:

- Exports the component type, instead of the props type, which is what should be exported
- Adds missing props to the props interface (based on PropTypes)
- Fixes the `type` prop, which can be either `text` or `number`, not any string.
- All the props appear to be optional, so I marked them optional (`?`).