### PR TITLE
refact: allow any for fieldWidth and fieldHeight

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,8 +7,8 @@ interface ReactCodeInputProps {
   fields?: number;
   loading?: boolean;
   title?: string;
-  fieldWidth?: number;
-  fieldHeight?: number;
+  fieldWidth?: any;
+  fieldHeight?: any;
   autoFocus?: boolean;
   className?: string;
   values?: string[];


### PR DESCRIPTION
Hiya,

Thanks for creating this component. I've made a minor adjustment that allows the `fieldWidth` and `fieldHeight` to be any type such as a string. This is useful when the styling of the input fields need to be relative to the parent, which in our case was necessary for responsiveness.

```tsx
<ReactCodeInput ...  fieldWidth="100%" fieldHeight="100%" />
 ```         
 
 Cheers! 