### PR TITLE
feat: add onFocus event

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ class Example extends Component {
 |   fields    | number |     The count of characters     |
 |  onChange   |  func  |   Trigger on character change   |
 | onComplete  |  func  | Trigger on all character inputs |
+|  onFocus    |  func  |   Trigger on input focus        |
 | fieldWidth  | number |           input width           |
 | fieldHeight | number |          input height           |
 |  autoFocus  |  bool  | auto focus first input on init  |

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,7 @@ interface ReactCodeInputProps {
   type?: 'text' | 'number';
   onChange?: (val: string) => void;
   onComplete?: (val: string) => void;
+  onFocus?: () => void;
   fields?: number;
   loading?: boolean;
   title?: string;
@@ -18,7 +19,7 @@ interface ReactCodeInputProps {
 }
 
 declare class ReactCodeInput extends React.Component<ReactCodeInputProps> {
-  __clearvalues__ : () => void;
+  __clearvalues__: () => void;
 }
 
 export default ReactCodeInput;

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ export default class ReactCodeInput extends Component {
     type: PropTypes.oneOf(['text', 'number']),
     onChange: PropTypes.func,
     onComplete: PropTypes.func,
+    onFocus: PropTypes.func,
     fields: PropTypes.number,
     loading: PropTypes.bool,
     title: PropTypes.string,
@@ -82,6 +83,11 @@ export default class ReactCodeInput extends Component {
     if (onComplete && val.length >= fields) {
       onComplete(val);
     }
+  };
+
+  triggerFocus = () => {
+    const { onFocus } = this.props;
+    onFocus && onFocus();
   };
 
   onChange = e => {
@@ -185,6 +191,7 @@ export default class ReactCodeInput extends Component {
 
   onFocus = e => {
     e.target.select(e);
+    this.triggerFocus()
   };
 
   render() {


### PR DESCRIPTION
Hi! First thank you very much for this package, it has been of great help.

This pull request comes to fulfill a need to capture the focus event, to precisely focus the fields on the screen when the user focuses on the field. 

The tests are passing

![image](https://user-images.githubusercontent.com/3098556/156605989-86a163ba-a8aa-42f6-9890-707080a5eb55.png)
